### PR TITLE
generate field 'extracted_at' with a timestamp for the http call

### DIFF
--- a/src/it/scala/com/pagantis/singer/flows/it/TestRequest.scala
+++ b/src/it/scala/com/pagantis/singer/flows/it/TestRequest.scala
@@ -1,5 +1,8 @@
 package com.pagantis.singer.flows.it
 
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
 import akka.actor.ActorSystem
 import akka.event.{Logging, LoggingAdapter}
 import akka.http.scaladsl.Http
@@ -12,14 +15,14 @@ import com.pagantis.singer.flows.BatchHttp.clazz
 import com.pagantis.singer.flows.Request
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Inside, Matchers}
 import spray.json.DefaultJsonProtocol
 
 import scala.concurrent.ExecutionContextExecutor
 import scala.util.Try
 import spray.json._
 
-class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with ScalaFutures {
+class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with ScalaFutures with Inside {
 
   // init actor system, loggers and execution context
   implicit val system: ActorSystem = ActorSystem("BatchHttp")
@@ -66,6 +69,11 @@ class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with S
         )
         fields("response") shouldBe a[JsArray]
         fields("context") shouldBe JsString("CvKL8")
+        inside (fields("extracted_at")) {
+          case JsString(extractedAt) =>
+            LocalDateTime.parse(extractedAt, DateTimeFormatter.ISO_DATE_TIME) shouldBe a[LocalDateTime]
+          case _ => fail
+        }
       }
     }
 
@@ -90,6 +98,11 @@ class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with S
           "body" -> JsString("bar"),
           "userId" -> JsNumber(1)
         )
+        inside (fields("extracted_at")) {
+          case JsString(extractedAt) =>
+            LocalDateTime.parse(extractedAt, DateTimeFormatter.ISO_DATE_TIME) shouldBe a[LocalDateTime]
+          case _ => fail
+        }
       }
     }
 

--- a/src/main/scala/com/pagantis/singer/flows/Request.scala
+++ b/src/main/scala/com/pagantis/singer/flows/Request.scala
@@ -1,5 +1,8 @@
 package com.pagantis.singer.flows
 
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest, HttpResponse, Uri}
 import akka.http.scaladsl.model.Uri.Query
 import akka.stream.Materializer
@@ -52,7 +55,7 @@ object Request {
 
     triedResponse match {
       case (Success(response), request) =>
-        Request.fromHttpResponse(response).map(request.toLine)
+        Request.fromHttpResponse(response).map(request.toLine(_))
       case (Failure(exception), _) => throw exception
     }
 
@@ -84,14 +87,15 @@ trait Request {
 
   def outputRequest: JsObject
 
-  def toLine(response: JsValue): String = {
+  def toLine(response: JsValue, extractedAt: LocalDateTime = LocalDateTime.now()): String = {
 
     val request = outputRequest
 
     val requestAndResponse =
       Map(
         "request" -> request,
-        "response" -> response
+        "response" -> response,
+        "extracted_at" -> JsString(extractedAt.format(DateTimeFormatter.ISO_DATE_TIME))
       )
 
     val outputKeys = context match {


### PR DESCRIPTION
On call response a timestamp is generated and appended to the results in the `extracted_at` field.