### PR TITLE
Use a natural request representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,18 @@ The results is a JSON line which gets printed to the `stdout` with both the `req
 }
 ```
 
-In general, to represent the HTTP request as a JSON object you should consider the following rules:
-* Wrap your request in a `request` object in the root. This will keep alignment with the response representation, which will contain the `request` and the `response`.
-* Inside your `request`, use a `method` field to indicate the [HTTP method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) to be used in the request. If no method is provided and no default method is configured, `GET` will be used.
+In general, to represent the HTTP request as a JSON object some rules are contemplated ([#17](https://github.com/digitalorigin/batch-http/issues/17))
+* The request must be wrapped in a `request` object in the JSON root.
+* Inside the `request`, a `method` field can be used to indicate the [HTTP method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) for the request. If no method is provided and no default method is configured, `GET` will be used.
 * The following attributes can also be specified to further refine the request.
-  * A `path` string for passing the path to be used in the request. If no path is provided in the request or in the configuration, `/` will be used as default.
-  * A `query` object for passing a set of key-value query parameters to be used in the request
-  * A `headers` object for passing a set of key-value headers to be used in the request
-  * A `body` object (for `POST` method only) for sending a generic JSON object in the request body
-* A response is represented in `response` object in the root. A `response` can also contain `headers` and `body`. The response status is represented in a `status` field.
+  * A `path` string for passing the path to be used in the request. If no path is provided in the request or in the configuration, `/` will be used.
+  * A `query` object for passing a set of key-value query parameters to be used in the request.
+  * A `headers` object for passing a set of key-value headers to be used in the request.
+  * A `body` object for sending a generic JSON object in the request body.
+* A response is represented in a `response` object in the root. A `response` can contain `headers` and `body` as well. The response status is represented in a `status` field.
 * Optionally a `context` object can also be passed in the root to allow for context propagation. This allows annotating input records with metadata which will not be used in the request ([#3](https://github.com/dcereijodo/batch-http/issues/3))
-* Any object or key not specified above will be simply ignored.
+
+Any object or key not specified above will be simply ignored.
 
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ provided the `endpoint` configuration value is set to `maps.googleapis.com`, it 
 https://maps.googleapis.com/maps/api/geocode/region=es&language=es&address=1600+Amphitheatre+Parkway,+Mountain+View,+CA
 ```
 The `endpoint` and `port` of the requests must be defined in the `application.conf` configuration file, whilst the `path`
-can be defined both in the configuration or in the `request` object takes precedence). The configuration
+can be defined both in the configuration or in the `request` object (the second takes precedence). The configuration
 file also supports additional secret query parameters. So with the following configuration file we can make a
 request to the [Google Geocoding service](https://developers.google.com/maps/documentation/geocoding/intro).
 ```hocon

--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 # BatchHttp [![CircleCI](https://circleci.com/gh/digitalorigin/batch-http.svg?style=svg&circle-token=d196d5b828e9e0debb5c25f04e7279c1f342d675)](https://circleci.com/gh/digitalorigin/batch-http)
-A tool for processing data batches through a REST API. It reads the `stdin` for JSON lines, converts each line to an HTTP call and
-then it makes the call. Finally it prints both the input line and the response to the `stdout`.
+A tool for processing HTTP request batches through a REST API. It reads the `stdin` for JSON lines representing HTTP requests,
+converts each line to an HTTP and executes it, providing both the request and the response as an output in the `stdout`.
 
-For example, when passed a JSON string (compacted in a single line)
-
+For example, when passed a JSON string such as
 ```json
  {
-   "query": {
-     "address": "1600 Amphitheatre Parkway, Mountain View, 9090",
-     "region":"es",
-     "language":"es"
-   }
+  "request": {
+    "method": "GET",
+    "path": "/maps/api/geocode/",
+    "query": {
+      "address": "1600 Amphitheatre Parkway, Mountain View, 9090",
+      "region":"es",
+      "language":"es"
+    }
+  }
  }
 ```
-
-it will make a request with a query parameters string
+provided the `endpoint` configuration value is set to `maps.googleapis.com`, it will make a `GET` request to the endpoint on
 ```console
-region=es&language=es&address=1600+Amphitheatre+Parkway,+Mountain+View,+CA
+https://maps.googleapis.com/maps/api/geocode/region=es&language=es&address=1600+Amphitheatre+Parkway,+Mountain+View,+CA
 ```
-The `endpoint` and `path` of the request can defined in the `application.conf` configuration file or they can be
-overridden by the `endpoint` and `path` keys in the input JSON payload (takes precedence). The configuration
+The `endpoint` and `port` of the requests must be defined in the `application.conf` configuration file, whilst the `path`
+can be defined both in the configuration or in the `request` object takes precedence). The configuration
 file also supports additional secret query parameters. So with the following configuration file we can make a
 request to the [Google Geocoding service](https://developers.google.com/maps/documentation/geocoding/intro).
 ```hocon
@@ -27,7 +29,6 @@ request to the [Google Geocoding service](https://developers.google.com/maps/doc
 flow {
 
   endpoint = "maps.googleapis.com"
-  path = "/maps/api/geocode/json"
 
   # additional parameters to be inculded in the http query if any
   extra_params {
@@ -40,6 +41,8 @@ The results is a JSON line which gets printed to the `stdout` with both the `req
 ```json
 {
   "request": {
+    "method": "GET",
+    "path": "/maps/api/geocode/",
     "query": {
       "address": "1600 Amphitheatre Parkway, Mountain View, 9090",
       "region":"es",
@@ -56,14 +59,18 @@ The results is a JSON line which gets printed to the `stdout` with both the `req
 }
 ```
 
-- If a `query` object is passed in the JSON, a request will be created with all parameters inside
-the object as URL parameters. `GET` method will be used.
+In general, to represent the HTTP request as a JSON object you should consider the following rules:
+* Wrap your request in a `request` object in the root. This will keep alignment with the response representation, which will contain the `request` and the `response`.
+* Inside your `request`, use a `method` field to indicate the [HTTP method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) to be used in the request. If no method is provided and no default method is configured, `GET` will be used.
+* The following attributes can also be specified to further refine the request.
+  * A `path` string for passing the path to be used in the request. If no path is provided in the request or in the configuration, `/` will be used as default.
+  * A `query` object for passing a set of key-value query parameters to be used in the request
+  * A `headers` object for passing a set of key-value headers to be used in the request
+  * A `body` object (for `POST` method only) for sending a generic JSON object in the request body
+* A response is represented in `response` object in the root. A `response` can also contain `headers` and `body`. The response status is represented in a `status` field.
+* Optionally a `context` object can also be passed in the root to allow for context propagation. This allows annotating input records with metadata which will not be used in the request ([#3](https://github.com/dcereijodo/batch-http/issues/3))
+* Any object or key not specified above will be simply ignored.
 
-- If a `body` object is passed in the JSON, a request will be created with the contents of `body`
-in the request body. `POST` method will be used.
-
-Whatever is passed in the input JSON in the `context` key it will be propagated unaltered to the result.
-This allows annotating input records with metadata which will not be used in the request ([#3](https://github.com/dcereijodo/batch-http/issues/3))
 
 ## Configuration
 You can find examples and descriptions for all configurations supported by `batch-http` in the [sample configuration file](src/main/resources/application.conf). All this properties can be overridden on invocation by providing appropriate [JVM arguments](https://github.com/lightbend/config).

--- a/src/it/scala/com/pagantis/singer/flows/it/TestRequest.scala
+++ b/src/it/scala/com/pagantis/singer/flows/it/TestRequest.scala
@@ -11,7 +11,6 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.{Sink, Source}
-import com.pagantis.singer.flows.BatchHttp.clazz
 import com.pagantis.singer.flows.Request
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
@@ -53,21 +52,20 @@ class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with S
   }
 
   "Request" should "get comments by post_id" in {
-    whenReady(makeRequestAndHandle("""{"request": {"get": {"query": {"post_id": 1}, "path": "/comments"}}}""")) {
+    whenReady(makeRequestAndHandle("""{"request": {"method": "GET", "query": {"post_id": 1}, "path": "/comments"}}""")) {
       response => response.parseJson.asJsObject.fields("response") shouldBe a[JsArray]
     }
 
-    whenReady(makeRequestAndHandle("""{"request": {"get": {"query": {"post_id": 1}, "path": "/comments"}}, "context": "CvKL8"}""")) {
+    whenReady(makeRequestAndHandle("""{"request": {"method": "GET", "query": {"post_id": 1}, "path": "/comments"}, "context": "CvKL8"}""")) {
       response => {
         val responseAsJson = response.parseJson.asJsObject
         val fields = responseAsJson.fields
         fields("request") shouldBe JsObject(
-          "get" -> JsObject(
-            "query" -> JsObject(
-              "post_id" -> JsNumber(1)
-            ),
-            "path" -> JsString("/comments")
-          )
+          "method" -> JsString("GET"),
+          "query" -> JsObject(
+            "post_id" -> JsNumber(1)
+          ),
+          "path" -> JsString("/comments")
         )
         fields("response") shouldBe a[JsArray]
         fields("context") shouldBe JsString("CvKL8")
@@ -81,19 +79,18 @@ class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with S
   }
 
   "Request" should "post posts with user_id" in {
-    whenReady(makeRequestAndHandle("""{"request": {"post": {"body": {"userId": 1, "title": "foo", "body": "bar"}, "path": "/posts"}}}""")) {
+    whenReady(makeRequestAndHandle("""{"request": {"method": "POST", "body": {"userId": 1, "title": "foo", "body": "bar"}, "path": "/posts"}}""")) {
       response => {
         val responseAsJson = response.parseJson.asJsObject
         val fields = responseAsJson.fields
         fields("request") shouldBe JsObject(
-          "post" -> JsObject(
-            "body" -> JsObject(
-              "title" -> JsString("foo"),
-              "body" -> JsString("bar"),
-              "userId" -> JsNumber(1)
-            ),
-            "path" -> JsString("/posts")
-          )
+          "method" -> JsString("POST"),
+          "body" -> JsObject(
+            "title" -> JsString("foo"),
+            "body" -> JsString("bar"),
+            "userId" -> JsNumber(1)
+          ),
+          "path" -> JsString("/posts")
         )
         fields("response") shouldBe JsObject(
           "id" -> JsNumber(101),

--- a/src/main/scala/com/pagantis/singer/flows/BatchHttp.scala
+++ b/src/main/scala/com/pagantis/singer/flows/BatchHttp.scala
@@ -37,7 +37,7 @@ object BatchHttp extends App {
   // This shutdown sequence was copied from another related issue: https://github.com/akka/akka-http/issues/907#issuecomment-345288919
   def shutdownSequence = {
     for {
-      http <- Http().shutdownAllConnectionPools()
+      _ <- Http().shutdownAllConnectionPools()
       akka <- system.terminate()
     } yield akka
   }

--- a/src/main/scala/com/pagantis/singer/flows/InvalidRequestException.scala
+++ b/src/main/scala/com/pagantis/singer/flows/InvalidRequestException.scala
@@ -1,0 +1,3 @@
+package com.pagantis.singer.flows
+
+case class InvalidRequestException(message: String = "Invalid request representation https://github.com/digitalorigin/batch-http/issues/17") extends Exception(message)

--- a/src/main/scala/com/pagantis/singer/flows/Request.scala
+++ b/src/main/scala/com/pagantis/singer/flows/Request.scala
@@ -121,17 +121,11 @@ case class Request(method: HttpMethod, methodContents: Map[String, JsValue], con
     }
   }
 
-  private def buildUri(optDomain: Option[JsValue], optPath: Option[JsValue], optQueryRaw: Option[JsValue]): Uri = {
-    val path = optPath match {
-      case Some(JsString(path)) => path
+  private def buildUri(optPath: Option[JsValue], optQueryRaw: Option[JsValue]): Uri = {
+    val uri = optPath match {
+      case Some(JsString(path)) => Uri.from(path = path)
       case Some(_) => throw InvalidRequestException("'path' must be an JSON string")
-      case None => Request.defaultPath
-    }
-
-    val uri = optDomain match {
-      case Some(JsString(domain)) =>  Uri.from(host = domain, path = path)
-      case Some(_) => throw InvalidRequestException("'domain' must be an JSON string")
-      case None => Uri.from(path = path)
+      case None => Uri.from(path = Request.defaultPath)
     }
 
     uri.withQuery(buildQuery(optQueryRaw))
@@ -140,7 +134,7 @@ case class Request(method: HttpMethod, methodContents: Map[String, JsValue], con
   def toAkkaRequest: HttpRequest = {
     val headers = buildHeaders(methodContents.get("header"))
     val entity = buildBody(methodContents.get("body") )
-    val uri = buildUri(methodContents.get("domain"), methodContents.get("path"), methodContents.get("query"))
+    val uri = buildUri(methodContents.get("path"), methodContents.get("query"))
 
     HttpRequest(
       method = method,

--- a/src/main/scala/com/pagantis/singer/flows/Request.scala
+++ b/src/main/scala/com/pagantis/singer/flows/Request.scala
@@ -99,7 +99,8 @@ case class Request(method: HttpMethod, methodContents: Map[String, JsValue], con
       case Some(JsObject(fields)) => Query(
         fields.mapValues {
           case JsString(value) => value
-          case value => throw InvalidRequestException(s"invalid query parameter $value: it must be a string")
+          case JsNumber(value) => value.toString
+          case value => throw InvalidRequestException(s"invalid query parameter $value: it must be a string or a number")
         } ++ Request.extraParams
       )
       case None if Request.extraParams.nonEmpty => Query(Request.extraParams)
@@ -112,7 +113,8 @@ case class Request(method: HttpMethod, methodContents: Map[String, JsValue], con
     rawHeaders match {
       case Some(JsObject(fields)) => fields map {
         case (header, JsString(value)) => RawHeader(header, value)
-        case header => throw InvalidRequestException(s"invalid header $header: it must be a string")
+        case (header, JsNumber(value)) => RawHeader(header, value.toString)
+        case header => throw InvalidRequestException(s"invalid header $header: it must be a string or a number")
       } toList
       case None => List()
       case _ => throw InvalidRequestException("'headers' member must be key-value map")

--- a/src/main/scala/com/pagantis/singer/flows/Request.scala
+++ b/src/main/scala/com/pagantis/singer/flows/Request.scala
@@ -80,8 +80,10 @@ case class Request(method: HttpMethod, methodContents: Map[String, JsValue], con
     val requestAndResponse =
       Map(
         "request" -> request,
-        "response" -> response,
-        "extracted_at" -> JsString(extractedAt.format(DateTimeFormatter.ISO_DATE_TIME))
+        "response" -> JsObject(
+          "body" -> response,
+          "responded_at" -> JsString(extractedAt.format(DateTimeFormatter.ISO_DATE_TIME))
+        )
       )
 
     val outputKeys = context match {

--- a/src/main/scala/com/pagantis/singer/flows/Request.scala
+++ b/src/main/scala/com/pagantis/singer/flows/Request.scala
@@ -3,92 +3,86 @@ package com.pagantis.singer.flows
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest, HttpResponse, Uri}
-import akka.http.scaladsl.model.Uri.Query
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpHeader, HttpMethods, HttpRequest, HttpResponse, Uri}
+import akka.http.scaladsl.model.Uri.{Path, Query}
+import akka.http.scaladsl.model.headers.RawHeader
 import akka.stream.Materializer
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
 import spray.json._
 
+import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.{Failure, Success, Try}
 
 object Request {
 
-  val config = ConfigFactory.load()
+  private val config = ConfigFactory.load()
 
-  val extraParams = config.as[Map[String, String]]("flow.extra_params")
-  val defaultPath = config.getString("flow.path")
+  private val extraParams: Map[String, String] =
+    config.as[Option[Map[String, String]]]("flow.extra_params") match {
+      case None => Map()
+      case Some(params) => params
+    }
 
-  def fromLine(line: String) = {
+  private val defaultPath = config.getString("flow.path")
+
+  def fromLine(line: String): Request = {
 
     val message = line.parseJson
-    val fields = message.asJsObject.fields
+    val rootFields = message.asJsObject.fields
+    val request = rootFields.get("request")
+    val optContext = rootFields.get("context")
 
-    (fields.get("query"), fields.get("body"), fields.get("path"), fields.get("context")) match {
-
-      case (Some(_), Some(_), _, _) =>
-        throw new Exception
-
-      case (Some(jsonQueryParams), None, optPath, optContext) =>
-
-        val asStringMap = jsonQueryParams
-          .asJsObject
-          .fields
-
-        val optStringPath = optPath collect { case JsString(value) => value }
-
-        GetRequest(asStringMap ++ extraParams.map(pair => (pair._1, JsString(pair._2))), optStringPath, optContext)
-
-      case (None, Some(jsonBody), optPath, optContext) =>
-
-        val optStringPath = optPath collect { case JsString(value) => value }
-
-        PostRequest(jsonBody.asJsObject, optStringPath, optContext)
+    request match {
+      case Some(JsObject(requestFields)) =>
+        (requestFields.get("get"), requestFields.get("post")) match {
+          case (Some(_), Some(_)) => throw InvalidRequestException("'get' and 'post' methods are mutually exclusive")
+          case (Some(JsObject(methodContents)), None) => Request(GET, methodContents, optContext)
+          case (None, Some(JsObject(methodContents))) => Request(POST, methodContents, optContext)
+          case _ => throw new InvalidRequestException
+        }
+      case _ => throw new InvalidRequestException
     }
+
 
   }
 
-  def parseResponse(triedResponse: (Try[HttpResponse], Request))(implicit am: Materializer) = {
-
-    implicit val ec = am.executionContext
+  def parseResponse(triedResponse: (Try[HttpResponse], Request))(implicit am: Materializer): Future[String] = {
+    implicit val ec: ExecutionContextExecutor = am.executionContext
 
     triedResponse match {
       case (Success(response), request) =>
         Request.fromHttpResponse(response).map(request.toLine(_))
       case (Failure(exception), _) => throw exception
     }
-
   }
 
-
-
-  def fromHttpResponse(response: HttpResponse)(implicit am: Materializer) = {
-
+  def fromHttpResponse(response: HttpResponse)(implicit am: Materializer): Future[JsValue] = {
     import spray.json._
-    implicit val ec = am.executionContext
+    implicit val ec: ExecutionContextExecutor = am.executionContext
 
     val responseAsJson = response.entity.dataBytes.runFold(ByteString(""))(_ ++ _) map
       (body => body.utf8String.parseJson)
 
-
     responseAsJson
-
   }
-
 }
 
+sealed trait RequestMethod
+case object GET extends RequestMethod
+case object POST extends RequestMethod
 
-trait Request {
+case class Request(method: RequestMethod, methodContents: Map[String, JsValue], context: Option[JsValue]) {
 
-  val context: Option[JsValue]
-
-  def toAkkaRequest: HttpRequest
-
-  def outputRequest: JsObject
+  def outputRequest: JsObject = {
+    method match {
+      case GET => JsObject("get" -> JsObject(methodContents))
+      case POST => JsObject("post" -> JsObject(methodContents))
+    }
+  }
 
   def toLine(response: JsValue, extractedAt: LocalDateTime = LocalDateTime.now()): String = {
-
     val request = outputRequest
 
     val requestAndResponse =
@@ -106,49 +100,42 @@ trait Request {
     JsObject(outputKeys).compactPrint
   }
 
-}
+  private def buildQueryString(query: Option[JsValue]) = {
+    query match {
+      case Some(JsObject(fields)) => Some(fields.mapValues(_.toString) ++ Request.extraParams)
+      case None if Request.extraParams.nonEmpty => Some(Request.extraParams)
+      case None => None
+      case _ => throw InvalidRequestException("'query' member must be key-value map")
+    }
+  }
 
-case class GetRequest(queryParams: Map[String, JsValue], path: Option[String] = None, context: Option[JsValue]) extends Request {
+  def buildHeaders(headers: Option[JsValue]): collection.immutable.Seq[HttpHeader] = {
+    headers match {
+      case Some(JsObject(fields)) => fields map { case (header, value) => RawHeader(header, value.toString) } toList
+      case None => List()
+      case _ => throw InvalidRequestException("'headers' member must be key-value map")
+    }
+  }
 
-  override def toAkkaRequest: HttpRequest = {
-
-    val query = Query(
-      queryParams
-        .collect {
-          case (key, JsString(value)) => (key, value)
-          case (key, JsNumber(value)) => (key, value.toString)
-      }
-    )
+  def baseRequest: HttpRequest = {
+    val queryString = buildQueryString(methodContents.get("query"))
+    val headers = buildHeaders(methodContents.get("header"))
 
     HttpRequest(
-      method = HttpMethods.GET,
-      uri = path match {
-        case None => Uri(Request.defaultPath).withQuery(query)
-        case Some(path) => Uri(path).withQuery(query)
-      }
+      uri = methodContents.get("path") match {
+        case Some(JsString(path)) => Uri(path = Path(path), queryString = queryString.map(Query(_).toString))
+        case _ => Uri(path = Path(Request.defaultPath), queryString = queryString.map(Query(_).toString))
+      },
+      headers = headers
     )
   }
 
-  override def outputRequest: JsObject = {
-
-    val noSecrets = queryParams.filter(param => !Request.extraParams.contains(param._1))
-
-    JsObject("query" -> JsObject(noSecrets))
+  def toAkkaRequest: HttpRequest = {
+    method match {
+      case GET => baseRequest.withMethod(HttpMethods.GET)
+      case POST => baseRequest.withMethod(HttpMethods.POST).withEntity(
+        HttpEntity(ContentTypes.`application/json`, methodContents.get("body").map(_.compactPrint).getOrElse(""))
+      )
+    }
   }
-
-}
-
-case class PostRequest(body: JsObject, path: Option[String] = None, context: Option[JsValue]) extends Request {
-
-  override def toAkkaRequest: HttpRequest = HttpRequest(
-    method = HttpMethods.POST,
-    uri = path match {
-      case None => Uri(Request.defaultPath)
-      case Some(path) => Uri(path)
-    },
-    entity = HttpEntity(ContentTypes.`application/json`, body.compactPrint)
-  )
-
-  override def outputRequest: JsObject = JsObject("body" -> body)
-
 }

--- a/src/test/scala/com/pagantis/singer/flows/test/TestRequest.scala
+++ b/src/test/scala/com/pagantis/singer/flows/test/TestRequest.scala
@@ -37,7 +37,8 @@ class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with I
   }
 
   "Request" should "create GET request" in {
-    val request = Request.fromLine(wrapRequest(get).compactPrint)
+    val context = JsString("some_id")
+    val request = Request.fromLine(wrapRequest(get, Some(context)).compactPrint)
 
     inside(request.toAkkaRequest) {
       case HttpRequest(HttpMethods.GET, _, headers, _, _) =>
@@ -45,7 +46,6 @@ class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with I
       case _ => fail
     }
 
-    val context = JsString("some_id")
     inside(request) {
       case Request(method, _, Some(requestContext)) =>
         method shouldBe HttpMethods.GET

--- a/src/test/scala/com/pagantis/singer/flows/test/TestRequest.scala
+++ b/src/test/scala/com/pagantis/singer/flows/test/TestRequest.scala
@@ -2,7 +2,7 @@ package com.pagantis.singer.flows.test
 
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest, Uri}
-import com.pagantis.singer.flows.Request
+import com.pagantis.singer.flows.{InvalidRequestException, Request}
 import org.scalatest.{FlatSpec, Inside, Matchers}
 import spray.json.{DefaultJsonProtocol, JsNumber, JsObject, JsString, JsValue}
 
@@ -39,50 +39,72 @@ class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with I
   "Request" should "create GET request" in {
     val request = Request.fromLine(wrapRequest(get).compactPrint)
 
-    inside(request) {
-      case Request(method, _, _) => method shouldBe HttpMethods.GET
+    inside(request.toAkkaRequest) {
+      case HttpRequest(HttpMethods.GET, _, headers, _, _) =>
+        headers should contain (RawHeader("Some header key", "Some header value"))
+      case _ => fail
     }
 
     val context = JsString("some_id")
-    inside(Request.fromLine(wrapRequest(get, Some(context)).compactPrint)) {
+    inside(request) {
       case Request(method, _, Some(requestContext)) =>
         method shouldBe HttpMethods.GET
         requestContext shouldBe context
       case _ => fail
     }
-
-    inside(request.toAkkaRequest) {
-      case HttpRequest(_, _, headers, _, _) =>
-        headers should contain (RawHeader("Some header key", "Some header value"))
-      case _ => fail
-    }
   }
 
   "Request" should "create POST request" in {
-    inside(Request.fromLine(wrapRequest(post).compactPrint)) {
-      case Request(method, _, _) => method shouldBe HttpMethods.POST
-    }
-
     val context = JsObject("context" -> JsObject(Map("type" -> JsString("order"), "id" -> JsNumber(746))))
-    val request =
-      Request
-        .fromLine(wrapRequest(
-            post,
-            Some(context)
-          ).compactPrint)
-
-    inside(request) {
-      case Request(method, _, Some(requestContext)) =>
-        method shouldBe HttpMethods.POST
-        requestContext shouldBe context
-      case _ => fail
-    }
+    val request = Request.fromLine(wrapRequest(post, Some(context)).compactPrint)
 
     inside(request.toAkkaRequest) {
-      case HttpRequest(_, Uri(_, _, path, rawQueryString, _), _, _, _) =>
+      case HttpRequest(HttpMethods.POST, Uri(_, _, path, rawQueryString, _), _, _, _) =>
         rawQueryString shouldBe Some("var=var_value_1")
         path.toString shouldBe "/some_path"
       case _ => fail
     }
+
+    inside(request) {
+      case Request(_, _, Some(requestContext)) =>
+        requestContext shouldBe context
+      case _ => fail
+    }
+  }
+
+  "Request" should "fail invalid representations" in {
+    assertThrows[InvalidRequestException] { Request.fromLine("""{}""") }
+
+    (intercept[InvalidRequestException] {
+      Request.fromLine("""{"request": {"method": "INVALID_METHOD"}}""")
+    } getMessage) shouldBe "'method' must be a valid HTTP method"
+
+    (intercept[InvalidRequestException] {
+      Request.fromLine("""{"request": {"method": 200}}""")
+    } getMessage) shouldBe "'method' must be a JSON string"
+
+    (intercept[InvalidRequestException] {
+      Request.fromLine("""{"request": {"method": "GET", "query": {"param": {}}}}""").toAkkaRequest
+    } getMessage) shouldBe "invalid query parameter {}: it must be a string or a number"
+
+    (intercept[InvalidRequestException] {
+      Request.fromLine("""{"request": {"method": "GET", "query": "query_val"}}""").toAkkaRequest
+    } getMessage) shouldBe "'query' member must be key-value map"
+
+    (intercept[InvalidRequestException] {
+      Request.fromLine("""{"request": {"method": "GET", "headers": {"header_1": {}}}}""").toAkkaRequest
+    } getMessage) shouldBe "invalid header (header_1,{}): it must be a string or a number"
+
+    (intercept[InvalidRequestException] {
+      Request.fromLine("""{"request": {"method": "GET", "headers": "header_val"}}""").toAkkaRequest
+    } getMessage) shouldBe "'headers' member must be key-value map"
+
+    (intercept[InvalidRequestException] {
+      Request.fromLine("""{"request": {"method": "POST", "body": "body_val"}}""").toAkkaRequest
+    } getMessage) shouldBe "'body' must be a full JSON object"
+
+    (intercept[InvalidRequestException] {
+      Request.fromLine("""{"request": {"method": "POST", "body": {}, "path": {}}}""").toAkkaRequest
+    } getMessage) shouldBe "'path' must be an JSON string"
   }
 }

--- a/src/test/scala/com/pagantis/singer/flows/test/TestRequest.scala
+++ b/src/test/scala/com/pagantis/singer/flows/test/TestRequest.scala
@@ -1,26 +1,25 @@
 package com.pagantis.singer.flows.test
 
-import com.pagantis.singer.flows.{GET, POST, Request}
+import akka.http.scaladsl.model.HttpMethods
+import com.pagantis.singer.flows.Request
 import org.scalatest.{FlatSpec, Inside, Matchers}
 import spray.json.{DefaultJsonProtocol, JsNumber, JsObject, JsString, JsValue}
 
 class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with Inside{
 
   val get: JsObject = JsObject(
-    "get" -> JsObject(
-      "query" -> JsObject(
-        "parm1" -> JsString("value1"),
-        "parm2" -> JsString("value2")
-      )
+    "method" -> JsString("GET"),
+    "query" -> JsObject(
+      "parm1" -> JsString("value1"),
+      "parm2" -> JsString("value2")
     )
   )
 
   val post: JsObject = JsObject(
-    "post" -> JsObject(
-      "body" -> JsObject(
-        "parm1" -> JsString("value1"),
-        "parm2" -> JsString("value2")
-      )
+    "method" -> JsString("POST"),
+    "body" -> JsObject(
+      "parm1" -> JsString("value1"),
+      "parm2" -> JsString("value2")
     )
   )
 
@@ -31,25 +30,33 @@ class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with I
 
   "Request" should "create GET request when a get method object is passed" in {
     inside(Request.fromLine(wrapRequest(get).compactPrint)) {
-      case Request(method, _, _) => method shouldBe GET
+      case Request(method, _, _) => method shouldBe HttpMethods.GET
     }
-    inside(Request.fromLine(wrapRequest(get, Some(JsString("some_id"))).compactPrint)) {
-      case Request(method, _, _) => method shouldBe GET
+    val context = JsString("some_id")
+    inside(Request.fromLine(wrapRequest(get, Some(context)).compactPrint)) {
+      case Request(method, _, Some(requestContext)) =>
+        method shouldBe HttpMethods.GET
+        requestContext shouldBe context
+      case _ => fail
     }
   }
 
   "Request" should "create POST request when a body is passed" in {
     inside(Request.fromLine(wrapRequest(post).compactPrint)) {
-      case Request(method, _, _) => method shouldBe POST
+      case Request(method, _, _) => method shouldBe HttpMethods.POST
     }
+    val context = JsObject("context" -> JsObject(Map("type" -> JsString("order"), "id" -> JsNumber(746))))
     val request =
       Request
         .fromLine(wrapRequest(
             post,
-            Some(JsObject("context" -> JsObject(Map("type" -> JsString("order"), "id" -> JsNumber(746)))))
+            Some(context)
           ).compactPrint)
     inside(request) {
-      case Request(method, _, _) => method shouldBe POST
+      case Request(method, _, Some(requestContext)) =>
+        method shouldBe HttpMethods.POST
+        requestContext shouldBe context
+      case _ => fail
     }
   }
 }

--- a/src/test/scala/com/pagantis/singer/flows/test/TestRequest.scala
+++ b/src/test/scala/com/pagantis/singer/flows/test/TestRequest.scala
@@ -1,6 +1,7 @@
 package com.pagantis.singer.flows.test
 
-import akka.http.scaladsl.model.HttpMethods
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, Uri}
 import com.pagantis.singer.flows.Request
 import org.scalatest.{FlatSpec, Inside, Matchers}
 import spray.json.{DefaultJsonProtocol, JsNumber, JsObject, JsString, JsValue}
@@ -12,6 +13,9 @@ class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with I
     "query" -> JsObject(
       "parm1" -> JsString("value1"),
       "parm2" -> JsString("value2")
+    ),
+    "headers" -> JsObject(
+      "Some header key" -> JsString("Some header value")
     )
   )
 
@@ -20,7 +24,11 @@ class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with I
     "body" -> JsObject(
       "parm1" -> JsString("value1"),
       "parm2" -> JsString("value2")
-    )
+    ),
+    "query" -> JsObject(
+      "var" -> JsString("var_value_1")
+    ),
+    "path" -> JsString("/some_path")
   )
 
   private def wrapRequest(methodObject: JsObject, optContext: Option[JsValue] = None) = optContext match {
@@ -28,10 +36,13 @@ class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with I
     case None => JsObject("request" -> methodObject)
   }
 
-  "Request" should "create GET request when a get method object is passed" in {
-    inside(Request.fromLine(wrapRequest(get).compactPrint)) {
+  "Request" should "create GET request" in {
+    val request = Request.fromLine(wrapRequest(get).compactPrint)
+
+    inside(request) {
       case Request(method, _, _) => method shouldBe HttpMethods.GET
     }
+
     val context = JsString("some_id")
     inside(Request.fromLine(wrapRequest(get, Some(context)).compactPrint)) {
       case Request(method, _, Some(requestContext)) =>
@@ -39,12 +50,19 @@ class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with I
         requestContext shouldBe context
       case _ => fail
     }
+
+    inside(request.toAkkaRequest) {
+      case HttpRequest(_, _, headers, _, _) =>
+        headers should contain (RawHeader("Some header key", "Some header value"))
+      case _ => fail
+    }
   }
 
-  "Request" should "create POST request when a body is passed" in {
+  "Request" should "create POST request" in {
     inside(Request.fromLine(wrapRequest(post).compactPrint)) {
       case Request(method, _, _) => method shouldBe HttpMethods.POST
     }
+
     val context = JsObject("context" -> JsObject(Map("type" -> JsString("order"), "id" -> JsNumber(746))))
     val request =
       Request
@@ -52,10 +70,18 @@ class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with I
             post,
             Some(context)
           ).compactPrint)
+
     inside(request) {
       case Request(method, _, Some(requestContext)) =>
         method shouldBe HttpMethods.POST
         requestContext shouldBe context
+      case _ => fail
+    }
+
+    inside(request.toAkkaRequest) {
+      case HttpRequest(_, Uri(_, _, path, rawQueryString, _), _, _, _) =>
+        rawQueryString shouldBe Some("var=var_value_1")
+        path.toString shouldBe "/some_path"
       case _ => fail
     }
   }

--- a/src/test/scala/com/pagantis/singer/flows/test/TestRequest.scala
+++ b/src/test/scala/com/pagantis/singer/flows/test/TestRequest.scala
@@ -1,45 +1,55 @@
 package com.pagantis.singer.flows.test
 
-import com.pagantis.singer.flows.{GetRequest, PostRequest, Request}
-import org.scalatest.{FlatSpec, Matchers}
-import spray.json.{DefaultJsonProtocol, JsNumber, JsObject, JsString}
+import com.pagantis.singer.flows.{GET, POST, Request}
+import org.scalatest.{FlatSpec, Inside, Matchers}
+import spray.json.{DefaultJsonProtocol, JsNumber, JsObject, JsString, JsValue}
 
-class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol {
+class TestRequest extends FlatSpec with Matchers with DefaultJsonProtocol with Inside{
 
-  val query = JsObject(
-    "query" -> JsObject(
-      "parm1" -> JsString("value1"),
-      "parm2" -> JsString("value2")
+  val get: JsObject = JsObject(
+    "get" -> JsObject(
+      "query" -> JsObject(
+        "parm1" -> JsString("value1"),
+        "parm2" -> JsString("value2")
+      )
     )
   )
 
-  val body = JsObject(
-    "body" -> JsObject(
-      "parm1" -> JsString("value1"),
-      "parm2" -> JsString("value2")
+  val post: JsObject = JsObject(
+    "post" -> JsObject(
+      "body" -> JsObject(
+        "parm1" -> JsString("value1"),
+        "parm2" -> JsString("value2")
+      )
     )
   )
 
-  "Request" should "create GET request when a query map is passed" in {
+  private def wrapRequest(methodObject: JsObject, optContext: Option[JsValue] = None) = optContext match {
+    case Some(context) => JsObject("request" -> methodObject, "context" -> context)
+    case None => JsObject("request" -> methodObject)
+  }
 
-    Request.fromLine(query.compactPrint) shouldBe a[GetRequest]
-    Request.fromLine(
-      JsObject(
-        query.fields + ("context" -> JsString("some_id"))
-      ) compactPrint
-    ) shouldBe a[GetRequest]
-
+  "Request" should "create GET request when a get method object is passed" in {
+    inside(Request.fromLine(wrapRequest(get).compactPrint)) {
+      case Request(method, _, _) => method shouldBe GET
+    }
+    inside(Request.fromLine(wrapRequest(get, Some(JsString("some_id"))).compactPrint)) {
+      case Request(method, _, _) => method shouldBe GET
+    }
   }
 
   "Request" should "create POST request when a body is passed" in {
-
-    Request.fromLine(body.compactPrint) shouldBe a[PostRequest]
-    Request.fromLine(
-      JsObject(
-        body.fields + ("context" -> JsObject(Map("type" -> JsString("order"), "id" -> JsNumber(746))))
-      ) compactPrint
-    ) shouldBe a[PostRequest]
-
+    inside(Request.fromLine(wrapRequest(post).compactPrint)) {
+      case Request(method, _, _) => method shouldBe POST
+    }
+    val request =
+      Request
+        .fromLine(wrapRequest(
+            post,
+            Some(JsObject("context" -> JsObject(Map("type" -> JsString("order"), "id" -> JsNumber(746)))))
+          ).compactPrint)
+    inside(request) {
+      case Request(method, _, _) => method shouldBe POST
+    }
   }
-
 }


### PR DESCRIPTION
Closes #17 

- [x] Re-think whether is a good idea to use a full JSON level to represent the method or if it would be better a simple attribute
- [x] Wrap response body
- [x] Remove `domain` from request parameters as it will be constant
- [x] Create tests for added support for `headers`
- [x] Create tests for added custom exception
- [ ]  Scaladoc
- [x] Update README.md